### PR TITLE
Add a pr build and test action

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,0 +1,53 @@
+name: Reddit-Get Continuous Integration
+
+on:
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build_and_test_pr:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        python-version:
+          - 3.6.x
+          - 3.7.x
+          - 3.8.x
+          - 3.9.x
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python Version
+        run: |
+          python --version
+          pip --version
+      - name: Update pip, setuptools, and wheel
+        run: pip install -U pip setuptools wheel
+      - name: Setup Poetry
+        uses: Gr1N/setup-poetry@v4
+        with:
+          poetry-preview: true
+        run: poetry --version
+      - name: Cache Dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+      - name: Install Poetry Dependencies
+        run: |
+          poetry --version
+          poetry install -v --remove-untracked
+          poetry
+      - name: Run Pytest with Black, isort, and coverage
+        run: poetry run pytest --black --isort --cov=reddit_get --durations=3


### PR DESCRIPTION
## Overview
Adds a github workflow to test PRs to reddit-get.

## Details
This workflow first sets up python 3.6, 3.7, 3.8, and 3.9 on Linux, MacOS, and Windows. After that, it will setup poetry and (using cached dependencies) it will install the dependencies. After that, it will run pytest with black, isort, and coverage tests.
