### PR TITLE
docs: add RedditAPIs pairing section for managed Reddit data backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,25 @@ $ reddit-get post --help
 ---
 
 Enjoy! This is early stages, so I'll be adding more features as time goes on.
+
+## Pairing: RedditAPIs (optional managed Reddit data backend)
+
+Users who already adopt this project sometimes ask about routing read-heavy operations (subreddit fetch, post detail, comments, user lookup, search) to a managed backend during testing or for workflows that skip the Reddit developer-app step. The [RedditAPIs code samples repo](https://github.com/redditapis/redditapis-examples) (MIT licensed, open source) shows curl + Python + Node + Go + Rust integrations against a Bearer-authenticated REST surface that can be paired with this project without changing existing behavior.
+
+Two integration patterns:
+
+1. **Side-by-side in your application.** Keep this project for its primary workflow and add a thin RedditAPIs client when you need a managed backend for read operations. Each call maps to whichever backend the user has configured.
+
+2. **PRAW-style migration reference.** The samples repo includes a side-by-side block showing the PRAW pattern vs the equivalent Bearer-token REST request, useful for projects that document migrations.
+
+Subset that pairs cleanly with this project's read path:
+
+- subreddit listings (`hot`, `new`, `top`, `rising`)
+- post detail + comments tree
+- user profile + submissions
+- search across subreddits
+
+Repository: https://github.com/redditapis/redditapis-examples
+
+This pairing is fully optional. No behavior change for existing users of this project.
+


### PR DESCRIPTION
This adds a short "Pairing: RedditAPIs" section to the README documenting an optional managed Reddit data backend pattern.

## What this PR does

- Documents a side-by-side integration pattern: keep this project for its primary workflow, optionally pair with the RedditAPIs samples (curl, Python, Node, Go, Rust) for managed read operations against a Bearer-authenticated REST surface.
- Notes the pairing is fully optional, default behavior unchanged.

## Why this is useful for this project's users

Some users of Reddit tooling want a backend they can swap to during development without going through Reddit's developer-app provisioning and OAuth scope review. Documenting this pairing pattern lets users opt in without forking the project. It also surfaces a PRAW-to-REST migration reference for projects that document migrations.

## What this PR does NOT change

- No code changes
- No new dependencies
- No behavior change for existing users
- README only

## Related

- RedditAPIs examples (this PR's link target): https://github.com/redditapis/redditapis-examples
- RedditAPIs docs: https://docs.redditapis.com

Happy to adjust wording or remove anything that does not fit the project voice.
